### PR TITLE
Prepare release 1.4.2

### DIFF
--- a/git-cliff.toml
+++ b/git-cliff.toml
@@ -1,9 +1,9 @@
 [changelog]
-header = "## What's Changed\n"
+header = "# What's Changed in 1.4.2\n"
 body = """
 {% for group, commits in commits | group_by(attribute='group') %}
     ## {{ group | striptags | trim | upper }}
-    
+
     {% for commit in commits %}
         {% if commit.scope %}
         - **{{ commit.scope }}**: {{ commit.message | trim }} ({{ commit.id | truncate(count=11) }})
@@ -19,11 +19,8 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "**Features**" },
-    { message = "^fix|^hotfix", group = "**Bug Fixes**" },
-    { message = "^refactor", group = "**Refactors**" },
-    { message = "^chore", group = "**Chore**" },
-    { message = "^docs", group = "**Documentation**" },
-    { message = "^test", group = "**Tests**" },
-    { message = "^perf", group = "**Performance**" },
+         { message = "^feat", group = "**🚀Features**" },
+         { message = "^fix|^hotfix", group = "**🐛 Bug Fixes**" },
+         { message = "^refactor", group = "**🏗 Refactors**" },
+         { message = "^docs", group = "**📚 Documentation**" },
 ]

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-	"name": "Peperehobbits01Bot",
-	"version": "1.4.1",
-	"description": "Bot de Peperehobbits01",
-	"main": "main.js",
-	"scripts": {
-		"test": "node main"
-	},
-	"author": "Peperehobbits01",
-	"license": "LGPL-3.0-or-later",
-	"dependencies": {
-		"@discordjs/rest": "^2.6.1",
-		"@discordjs/voice": "^0.18.0",
-		"canvas": "^3.2.3",
-		"discord.js": "^14.26.4",
-		"dotenv": "^17.4.2",
-		"ms": "^2.1.3",
-		"mysql2": "^3.23.2",
-		"rss-parser": "^3.12.0"
-	}
+  "name": "Peperehobbits01Bot",
+  "version": "1.4.2",
+  "description": "Bot de Peperehobbits01",
+  "main": "main.js",
+  "scripts": {
+    "test": "node main"
+  },
+  "author": "Peperehobbits01",
+  "license": "LGPL-3.0-or-later",
+  "dependencies": {
+    "@discordjs/rest": "^2.6.1",
+    "@discordjs/voice": "^0.18.0",
+    "canvas": "^3.2.3",
+    "discord.js": "^14.26.4",
+    "dotenv": "^17.4.2",
+    "ms": "^2.1.3",
+    "mysql2": "^3.23.2",
+    "rss-parser": "^3.12.0"
+  }
 }


### PR DESCRIPTION
1.4.2

# What's Changed in 1.4.2

## **🐛 BUG FIXES**



- the label for the unban button in command ban is incorrect. (61160190b9caa6093422472d7f7da62693b39fb6)



- fixed rank layout to be more readable. (0ffe307b47928e70d4a20c454ce11fc1aa6fbc68)



- moved up of 5px the rank, level and experience info to fix overlapping and to center with the elements on the left (73a54fde4f33d42650083bc6fbc98a08fdf998d6)



- #ID in vocal logs embeds. Fixes #70 (d4abf27c0d37f73a6529d7b37f48af397464a96c)



- prevent deleted users to appear in rank and leaderboard. Fixes #67 (78c3f25de97587903a37069b0d71f272a5bc857f)



## **🚀FEATURES**



- add invite logging by simply sending to member safety page of the guild, because trying to actually log would require cahing, and it is not suitable for large bots/servers (e0318bd3925b1de652331029d4367e60a6e03cc1)



## FEAT



- Use Permanent Marker as font for rank and leaderboard text. (4762e8b5fa6c8c1c7b3ba51d2b9db06b458c0c41)



## FIX



- Rank progression bar percentage is unreadable (21e32af61ded8a43b194419d400469f92f993c71)



## CHORE



- Make base the main branch. Fixes #65 (4af7e935b792d00517abf76f791083a79a37d341)



- Added émojis to release changelogs. Fixes #66 (4affa935f0ef95a30b83a2c206ae641ede04e82c)



- Added release label for newly created PR's by the workflow. (3158616570afa6fd2b511a710dac1e045ba71eda)



- Added auto assigned users and reviewers to Github workflow prepare-release.yml (481c7598774c9d4372bf1fbf5f247c64797280bb)



- update dependabot.yml to accommodate for the addition of release workflows. (1e3c50cfb7a8c955237c19f3ce2da0a8fdd1e0fe)



- change header of changelogs to add version number in. (d034a2bad42924a99d4a331103dfe722a844901f)



- bump version (74fa904bbc28ae2bbd3b4e3e08aa50f09e08e46b)



- removed unused dependencies to improve security of the bot. (879270b2feedbb07a9346a2a423855c62c0a69ba)



- fix an issue in prepare-release.yml workflow. (ac1ff7061171c63cdd6c214b940e4f3aa41a9ac2)



- fix Code of Conduct check box not being in feature-request template (253956159addc2e18ffc5bbba01fcc345930aad2)